### PR TITLE
Removed unnecessary parameter confirmationUrl for subject translation

### DIFF
--- a/Resources/views/Registration/email.txt.twig
+++ b/Resources/views/Registration/email.txt.twig
@@ -1,7 +1,7 @@
 {% trans_default_domain 'FOSUserBundle' %}
 {% block subject %}
 {% autoescape false %}
-{{ 'registration.email.subject'|trans({'%username%': user.username, '%confirmationUrl%': confirmationUrl}) }}
+{{ 'for '|trans({'%username%': user.username}) }}
 {% endautoescape %}
 {% endblock %}
 {% block body_text %}


### PR DESCRIPTION
The parameter confirmationUrl is only translated in the body of the mail, no need to pass it for the translation of registration.email.subject
